### PR TITLE
fix the lock directory garbage on macOS

### DIFF
--- a/pcllock
+++ b/pcllock
@@ -33,7 +33,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-27
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -80,7 +80,7 @@ print_usage_and_exit () {
 	          stdout ....... enerated path of the lockfile (just lock-id)
 	Example : write the following line into the crontab file someone owned
 	          * * * * * pcllock -l 300 -w 10 -d /PATH/TO/LOCKDIR
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-27 23:55:00 JST
 	USAGE
   exit 1
 }

--- a/pcllock
+++ b/pcllock
@@ -381,7 +381,7 @@ tmpf_time=$(mktempf0) || {
 # (And also remove the orphaned sh-lock access token file "modifying")
 touch -t $(expire_date_and_time $max_lifetime_secs) "$tmpf_time"
 find './' -type f \( \! -newer "$tmpf_time" \) |
-grep -E '^./[^/]+(|/[^/]+/modifying)$'         | # <- with sh-lock access
+grep -E '^./[^/]+($|/[^/]+\.modifying$)'       | # <- with sh-lock access
 # 1:old_ex-files                               # #    token file "modifying"
 xargs grep '^' /dev/null                       |
 grep ':[0-9]\{1,\}$'                           |
@@ -410,7 +410,7 @@ do
     try=1
   fi
   while [ $try -gt 0 ]; do
-    File_modlk="${Dir_lock}$lockname/$lockname/modifying"
+    File_modlk="${Dir_lock}$lockname/$lockname.modifying"
     (set -C; umask 0000; echo $$ > "$File_modlk") 2>/dev/null || {
       [ $max_waiting_secs -ge 0 ] && try=$((try-1))   # retry if already exists
       case $try in 0) :;; *) sleep 1;; esac

--- a/pshlock
+++ b/pshlock
@@ -272,8 +272,8 @@ for lockname in ${1+"$@"}; do
       break                                           # finish if succeed to mv
     }
     # 1-2) try to create the accesing right token file "modifying"
-    File_modlk="$Dir_lock$lockname/$lockname/modifying"
-    (set -C; echo $ppid > 'modifying') 2>/dev/null || {
+    File_modlk="$Dir_lock$lockname/$lockname.modifying"
+    (set -C; echo $ppid > "../$lockname.modifying") 2>/dev/null || {
       File_modlk=''                                   # retry  if already exists
       [ $max_waiting_secs -ge 0 ] && try=$((try-1))
       case $try in 0) :;; *) sleep 1;; esac
@@ -282,7 +282,7 @@ for lockname in ${1+"$@"}; do
     # 1-3) check the current number of the locking processes
     n=$(ls -ld . 2>/dev/null | awk '{print $2-2;}')
     [ $max_num_of_sharing -lt 0 ] || [ $n -lt $max_num_of_sharing ] || {
-      rm -f 'modifying' 2>/dev/null                   # retry  if reached limit
+      rm -f "../$lockname.modifying" 2>/dev/null                   # retry  if reached limit
       File_modlk=''
       [ $max_waiting_secs -ge 0 ] && try=$((try-1))
       case $try in 0) :;; *) sleep 1;; esac
@@ -293,12 +293,12 @@ for lockname in ${1+"$@"}; do
     sublockname="$(date '+%Y%m%d%H%M%S').${s}.$ppid"
     mkdir $sublockname || {
       try=-1                                          # exit loop abnormally
-      rm -f 'modifying' 2>/dev/null
+      rm -f "../$lockname.modifying" 2>/dev/null
       File_modlk=''
       break
     }
     # 1-5) finish the loop successfully
-    rm -f 'modifying' 2>/dev/null
+    rm -f "../$lockname.modifying" 2>/dev/null
     File_modlk=''
     break
   done

--- a/pshlock
+++ b/pshlock
@@ -37,7 +37,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-27
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -92,7 +92,7 @@ print_usage_and_exit () {
 	Notice  : The lockfile is written with rw-rw-rw for sharing.
 	          If you want not to share it with others,
 	          you have to give the lockdir rwxrwx--- or rwx------ permisson.
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-27 23:55:00 JST
 	USAGE
   exit 1
 }

--- a/punlock
+++ b/punlock
@@ -25,7 +25,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-27
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -68,7 +68,7 @@ print_usage_and_exit () {
 	Notice  : The lockfile is written with rw-rw-rw for sharing.
 	          If you want not to share it with others,
 	          you have to give the lockdir rwxrwx--- or rwx------ permisson.
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-27 23:55:00 JST
 __USAGE
   exit 1
 }

--- a/punlock
+++ b/punlock
@@ -242,7 +242,7 @@ for lockname in ${1+"$@"}; do
   fi
   while [ $try -gt 0 ]; do
     # 1-2) try to create the accesing right token file "modifying"
-    File_modlk="${Dir_path}$lockname/modifying"
+    File_modlk="${Dir_path}$lockname.modifying"
     (set -C; echo $ppid > "$File_modlk") 2>/dev/null || {
       File_modlk=''                                   # retry  if already exists
       [ $max_waiting_secs -ge 0 ] && try=$((try-1))
@@ -269,7 +269,7 @@ for lockname in ${1+"$@"}; do
          ;;
     esac
     # 1-6) finish the loop successfully
-    rm -f "${Dir_path}$lockname/modifying" 2>/dev/null
+    rm -f "${Dir_path}$lockname.modifying" 2>/dev/null
     File_modlk=''
     break
   done


### PR DESCRIPTION
macOS で punlock を実行すると、共有ロックディレクトリが削除されないようです。

```
$ mkdir lockdir
$ l1=$(pshlock -d lockdir -w 10 foo)
$ punlock $l1
$ find lockdir
lockdir
lockdir/foo
lockdir/foo/foo
```

原因を調査したところ、macOSではディレクトリのリンクカウントにサブディレクトリだけでなくファイルも含まれるようです。

```
$ mkdir foo
$ ls -ld foo | awk '{print $2}'
2
$ mkdir foo/bar
$ ls -ld foo | awk '{print $2}'
3
$ touch foo/modifying
$ ls -ld foo | awk '{print $2}'
4
# 通常の UNIX では 3 のまま。リンクカウントを使うのはポータブルでない?
```

従って、サブディレクトリの存在しないディレクトリでも、ファイルが存在するとリンクカウントは 2 になりません。

サブディレクトリのカウントもファイルシステムで保持しているようですが、コマンドでの取得方法が分からなかったので、サブディレクトリ(=ロック)が存在するかどうかで判定するようにしてみました。もっと良い方法があればいいのですが。