### PR TITLE
Fix broken help message

### DIFF
--- a/exflock
+++ b/exflock
@@ -44,7 +44,7 @@
 #              :
 #          kill $flock_pid
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -69,15 +69,15 @@ export PATH="$(command -p getconf PATH)${PATH+:}${PATH-}"
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage  : ${0##*/} <seconds> <file> [maxlifetime]
+  cat <<-'USAGE' 1>&2
+	Usage  : exflock <seconds> <file> [maxlifetime]
 	         <seconds> ...... maximum waiting time to succeed locking
 	         <file> ......... the path of the file you want to lock
 	         [maxlifetime] .. the maximum life of the locking process (sec)
 	                          (0 means infinity, and default=$DEFAULT_MAXLIFETIME)
 	          * See the document at the source code of this command
 	            for more infomation
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/is_furigana
+++ b/is_furigana
@@ -33,7 +33,7 @@
 #    * blank (0x20) will be not also allowd
 #
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-03-17
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -57,8 +57,8 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage   : ${0##*/} [option] file
+  cat <<-'USAGE' 1>&2
+	Usage   : is_furigana [option] file
 	Args    : file
 	              A file to validate. ("-" means STDIN)
 	Opts    : --hira
@@ -71,7 +71,7 @@ print_usage_and_exit () {
 	              Accept only Zenkaku-Katagana
 	Ret     : $? ... 0 will be returned only when all of the given letters are
 	                 furigana
-	Version : 2017-07-18 22:50:17 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/mkcgipost
+++ b/mkcgipost
@@ -19,7 +19,7 @@
 #        stdout ... encoded CGI variables for HTTP POST(GET)
 #                   LF will NOT be added at the end of string
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -44,8 +44,8 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage   : ${0##*/} <file> [file...]
+  cat <<-'USAGE' 1>&2
+	Usage   : mkcgipost <file> [file...]
 	Argument: file
 	            A source file for you want to convert into HTTP POST string.
 	            The required format is
@@ -59,7 +59,7 @@ print_usage_and_exit () {
 	Return  : $? ....... 0 when all of the arguments are valid
 	          stdout ... encoded CGI variables for HTTP POST(GET)
 	                     LF will NOT be added at the end of string
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/name-cgi
+++ b/name-cgi
@@ -19,7 +19,7 @@
 #        stdout ... encoded CGI variables for HTTP POST(GET)
 #                   LF will NOT be added at the end of string
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -44,8 +44,8 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage   : ${0##*/} <file> [file...]
+  cat <<-'USAGE' 1>&2
+	Usage   : name-cgi <file> [file...]
 	Argument: file
 	            A source file for you want to convert into HTTP POST string.
 	            The required format is
@@ -59,7 +59,7 @@ print_usage_and_exit () {
 	Return  : $? ....... 0 when all of the arguments are valid
 	          stdout ... encoded CGI variables for HTTP POST(GET)
 	                     LF will NOT be added at the end of string
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/pcllock
+++ b/pcllock
@@ -12,7 +12,7 @@
 #                               1) this option "-d" if specified
 #                               2) the environment varriable "PLOCKDIR"
 #                                  if specified
-#                               3) "$(pwd)" (default)
+#                               3) $PWD (default)
 #           -w <maxwaiting> ... maximum waiting seconds to succeed unlocking
 #                               a shared lock
 #                               (-1 means waiting infinitely)
@@ -33,7 +33,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-27
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -57,15 +57,15 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage   : ${0##*/} [options]
+  cat <<-'USAGE' 1>&2
+	Usage   : pcllock [options]
 	Options : -d <lockdir> ...... the directory for lockfiles.
 	                              The lockfile directory will be decided
 	                              as the following rule.
 	                              1) this option "-d" if specified
 	                              2) the environment varriable "PLOCKDIR"
 	                                 if specified
-	                              3) "$(pwd)" (default)
+	                              3) $PWD (default)
 	          -w <maxwaiting> ... maximum waiting seconds to succeed unlocking
 	                              a shared lock
 	                              (-1 means waiting infinitely)
@@ -80,7 +80,7 @@ print_usage_and_exit () {
 	          stdout ....... enerated path of the lockfile (just lock-id)
 	Example : write the following line into the crontab file someone owned
 	          * * * * * pcllock -l 300 -w 10 -d /PATH/TO/LOCKDIR
-	Version : 2018-08-27 23:55:00 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/pexlock
+++ b/pexlock
@@ -33,7 +33,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2017-07-18
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -57,8 +57,8 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage   : ${0##*/} [options] <lockname> [lockname ...]
+  cat <<-'USAGE' 1>&2
+	Usage   : pexlock [options] <lockname> [lockname ...]
 	Options : -d <lockdir> ...... the directory for lockfiles.
 	                              The lockfile directory will be decided
 	                              as the following rule.
@@ -84,7 +84,7 @@ print_usage_and_exit () {
 	Notice  : The lockfile is written with rw-rw-rw for sharing.
 	          If you want not to share it with others,
 	          you have to give the lockdir rwxrwx--- or rwx------ permisson.
-	Version : 2017-07-18 02:39:39 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/pshlock
+++ b/pshlock
@@ -37,7 +37,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-27
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -61,9 +61,9 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-USAGE 1>&2
-	Usage   : ${0##*/} [options] <lockname> [lockname ...]
-	Options :  -n <maxsharing> ... the maximum number of sharing lock
+  cat <<-'USAGE' 1>&2
+	Usage   : pshlock [options] <lockname> [lockname ...]
+	Options : -n <maxsharing> ... the maximum number of sharing lock
 	                              This option is for using as a semaphore.
 	                              The default value is -1.
 	                              (-1 means infinity that is sharing lock)
@@ -92,7 +92,7 @@ print_usage_and_exit () {
 	Notice  : The lockfile is written with rw-rw-rw for sharing.
 	          If you want not to share it with others,
 	          you have to give the lockdir rwxrwx--- or rwx------ permisson.
-	Version : 2018-08-27 23:55:00 JST
+	Version : 2018-08-28 18:24:51 JST
 	USAGE
   exit 1
 }

--- a/punlock
+++ b/punlock
@@ -11,7 +11,7 @@
 #                               1) this option "-d" if specified
 #                               2) the environment varriable "PLOCKDIR"
 #                                  if specified
-#                               3) "$(pwd)" (default)
+#                               3) $PWD (default)
 #           -w <maxwaiting> ... <<for only lockfiles by "pshlock">>
 #                               maximum waiting seconds to succeed locking
 #                               (-1 means waiting infinitely)
@@ -25,7 +25,7 @@
 #           If you want not to share it with others,
 #           you have to give the lockdir rwxrwx--- or rwx------ permisson.
 #
-# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-27
+# Written by Shell-Shoccar Japan (@shellshoccarjpn) on 2018-08-28
 #
 # This is a public-domain software (CC0). It means that all of the
 # people can use this for any purposes with no restrictions at all.
@@ -49,15 +49,15 @@ export UNIX_STD=2003  # to make HP-UX conform to POSIX
 
 # === Define the functions for printing usage and error message ======
 print_usage_and_exit () {
-  cat <<-__USAGE 1>&2
-	Usage   : ${0##*/} [options] <lockname> [lockname ...]
+  cat <<-'USAGE' 1>&2
+	Usage   : punlock [options] <lockname> [lockname ...]
 	Options : -d <lockdir> ...... the directory for lockfiles.
 	                              The lockfile directory will be decided
 	                              as the following rule.
 	                              1) this option "-d" if specified
 	                              2) the environment varriable "PLOCKDIR"
 	                                 if specified
-	                              3) "$(pwd)" (default)
+	                              3) $PWD (default)
 	          -w <maxwaiting> ... <<for only lockfiles by "pshlock">>
 	                              maximum waiting seconds to succeed locking
 	                              (-1 means waiting infinitely)
@@ -68,8 +68,8 @@ print_usage_and_exit () {
 	Notice  : The lockfile is written with rw-rw-rw for sharing.
 	          If you want not to share it with others,
 	          you have to give the lockdir rwxrwx--- or rwx------ permisson.
-	Version : 2018-08-27 23:55:00 JST
-__USAGE
+	Version : 2018-08-28 18:24:51 JST
+	USAGE
   exit 1
 }
 warning() {


### PR DESCRIPTION
機能的な問題ではないです。

一部のコマンドで、ヘルプメッセージが表示されない・ヘルプ中の`$?`などの変数に見えるものが展開されて表示が崩れるなどしています。

```
$ pexlock -h
pexlock: line 60: pexlock: command not found
pexlock: line 60: lockid: unbound variable
```

好みあると思いますが、個人的には usage の内容が動的である必要はないと思っていますので、このように修正してみました。
